### PR TITLE
feat(codex): resume, cross-tool merge, and source labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 | **Prioritize** | Auto-ranks sessions and repos by urgency — dirty files don't age out, recent active work surfaces first. |
 | **Speed** | Parallelized BM25 search across gigabytes of past chats in seconds. Parallel git status scans across 50+ repos. |
 | **Cost Savings** | Uses Haiku to summarize past context once, then caches permanently — searching thousands of sessions costs nothing after first run. |
-| **Merge** | Merge multiple old chats together, pulling context across sessions into a single conversation. |
+| **Merge** | Merge multiple old chats together, pulling context across sessions into a single conversation — **including across tools**: bridge Codex research into a Claude Code session and vice versa. |
 
 ---
 
 ## MCP Server
 
-Add it to Claude Code and every session on your machine can search, read, and merge your full session history — in plain English.
+Add it to Claude Code and every session on your machine can search, read, and merge your full session history — in plain English. Indexes **both Claude Code and Codex CLI** sessions, so one query reaches across both tools.
 
 ```bash
 pip install resume-resume
@@ -101,6 +101,8 @@ What it does:
 
 No more "No conversation found" errors from being in the wrong folder.
 
+> The `cr` paste command parses `claude --resume` lines, so it's Claude Code only. Resuming a Codex session works through the MCP `resume_in_terminal` tool and the TUI/cards, which emit `codex resume <uuid>` and cd to the session's recorded cwd.
+
 ---
 
 ## TUI
@@ -134,7 +136,7 @@ Requires Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claud
 
 ## How It Works
 
-1. Scans `~/.claude/projects/` for JSONL session files
+1. Scans `~/.claude/projects/` (Claude Code) and `~/.codex/sessions/` (Codex CLI) for JSONL session files
 2. Scans all project directories for dirty git state (parallel `git status --porcelain`)
 3. Scores sessions by urgency: session recency (2h half-life) + repo dirty urgency (file count + dirty file recency)
 4. Dirty repos bypass age filters — uncommitted work doesn't age out

--- a/docs/DESCRIPTION.md
+++ b/docs/DESCRIPTION.md
@@ -20,6 +20,8 @@ resume-resume is two things in one package:
 
 The TUI is what you use when you sit down at your machine after a crash. The MCP server is what Claude uses to move context between sessions while you're working. Together, they turn Claude Code's flat pile of JSONL files into a navigable, searchable, composable session graph.
 
+This now extends beyond Claude Code: resume-resume also discovers and indexes **Codex CLI** sessions (`~/.codex/sessions/`), so a single search reaches across both agentic CLIs. Everything below describes Claude Code, but the same discovery, search, and resume machinery applies to Codex sessions.
+
 ## Why It Was Built
 
 ### The Crash Recovery Problem

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -42,6 +42,22 @@ truth instead of rediscovering the same problems every run.
 - **Test:** `tests/test_perf_regression.py::test_dirty_repos_cold_under_generous_ceiling`
   and `test_dirty_repos_cached_is_dramatically_faster_than_cold`
 
+### perf-004: broad single-token query latency (~50ms) — NOT bm25-bound, do not re-propose skip-bm25
+
+- **Severity:** ★ (paper cut; rare in practice)
+- **Evidence:** A lone ultra-common token matching ~all docs costs ~50ms
+  (`code` = 12,361 matches → 56ms; `session` = 12,762 → 63ms). Narrow /
+  multi-term / phrase queries are 2–11ms.
+- **Disproven fix:** Skipping `bm25()` ranking for broad lone tokens
+  (`ORDER BY s.mtime DESC` instead) was implemented and **measured at 1.0–1.2x
+  — i.e. no help** (`code`: 56.5ms with bm25 vs 54.9ms without). The cost is
+  the FTS5 posting scan + JOIN over every matching row, **not** ranking. The
+  guard was reverted. Do not re-propose it.
+- **Reality:** ~50ms to enumerate 12k matches is inherent FTS behaviour and
+  fine — a single ultra-common word is not a useful search. Real win, if ever
+  needed, is bounding match enumeration (e.g. a recency-scoped secondary FTS),
+  not touching the ranking expression.
+
 ### perf-002: `recent_sessions` is slow (FIXED 7b2d2d4)
 
 - Fixed. 10-second TTL cache. Cold path still ~1200ms (upstream
@@ -68,6 +84,45 @@ truth instead of rediscovering the same problems every run.
   with `{"full_new_text": ...`. Approval would have silently failed with
   `apply_error` set. Fixed by `_coerce_diff` which best-effort
   json-decodes strings that look like JSON before dispatching.
+
+### correctness-003: same-day sessions invisible (index-freshness gap) (FIXED 31d8419)
+
+- **Severity:** ★★★ (was user-visible — a same-day Codex session
+  "nevereatalone" was unfindable by keyword)
+- **Why it mattered:** A session newer than the 30-min hot window but not yet
+  appended to the daemon `SessionIndex` (and therefore absent from the cold
+  FTS index too) fell into a gap and was invisible to both search tiers.
+- **Fix:** `mcp_server._fresh_sessions()` supplements the live hot scan with a
+  bounded (6h window, cap 200) filesystem scan of fresh-but-unindexed sessions,
+  so same-day sessions are findable without waiting for a background ingestion
+  pass. The filesystem scan uses `find_all_sessions`, which discovers both
+  `~/.claude/projects` and `~/.codex/sessions`.
+- **Test:** `tests/test_index_freshness.py`
+
+### correctness-004: Codex CLI sessions now indexed alongside Claude Code
+
+- **Severity:** N/A (feature, documented for future agents)
+- **What:** `claude-session-commons` discovery + parse now handle Codex rollout
+  files (`~/.codex/sessions/**/rollout-*.jsonl`, `event_msg`/`response_item`
+  schema) and emit the same `(context, search_text)` shape as Claude sessions,
+  so all search/recent/digest tools cover both tools transparently.
+- **Note:** `search_text` is stored untruncated — a 64KB head+tail cap was
+  tried and reverted because it traded search recall for an index-size win that
+  wasn't needed (and gave no latency benefit; see perf-004).
+- **Resume:** Codex sessions resume via `resume_in_terminal` / TUI / cards /
+  the `cr` CLI (`cr codex resume <uuid>`, `cr <rollout-id>`), all of which emit
+  `codex resume <uuid>` (UUID extracted from the rollout stem) and cd to the
+  session's recorded cwd. `session_utils.resume_command()` is the single source
+  of truth for resume-command construction across sources.
+  Tests: `tests/test_resume_command.py`.
+- **Cross-tool context merge:** `merge_context` now works on Codex sessions in
+  all modes. `_read_messages` maps Codex `event_msg`/`user_message` and
+  `agent_message` entries to the same `{role, text}` shape as Claude
+  user/assistant entries — so you can pull Codex research into a Claude session
+  (and vice versa). Test: `tests/test_codex_crosstool.py`.
+- **Source labeling:** `search_sessions` items carry a `tool` field
+  (`"claude"` | `"codex"`, via `session_tool()`) so mixed results are
+  distinguishable.
 
 ### correctness-002: `self_*` list tools used to return bare lists (FIXED 29d2f73)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resume-resume"
-version = "0.5.5"
+version = "0.6.0"
 description = "Post-crash Claude Code session recovery TUI"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
-    "claude-session-commons>=0.1.0",
+    "claude-session-commons>=0.2.0",
     "textual>=0.40",
     "numpy",
     "fastmcp>=2.0",

--- a/resume_resume/cli.py
+++ b/resume_resume/cli.py
@@ -482,16 +482,46 @@ def _find_session_project(session_id: str) -> str | None:
     return None
 
 
-def _parse_resume_args(argv: list[str]) -> tuple[str | None, list[str]]:
-    """Parse a pasted claude command into (session_id, extra_flags).
+def _find_codex_project(session_id: str) -> str | None:
+    """Find the cwd recorded in a Codex rollout's session_meta.
+
+    Accepts either a full rollout id or a bare conversation UUID.
+    """
+    from claude_session_commons.codex import (
+        CODEX_SESSIONS_DIR,
+        _read_codex_cwd,
+        codex_session_uuid,
+    )
+
+    target = codex_session_uuid(session_id)
+    if not CODEX_SESSIONS_DIR.exists():
+        return None
+    for f in CODEX_SESSIONS_DIR.glob("**/rollout-*.jsonl"):
+        if target in f.stem:
+            return _read_codex_cwd(f) or None
+    return None
+
+
+def _parse_resume_args(argv: list[str]) -> tuple[str | None, list[str], bool, str]:
+    """Parse a pasted resume command into (session_id, extra_flags, is_codex, verb).
 
     Handles:  cr claude --resume <id> --model opus --chrome
               cr --resume <id>
-              cr <bare-uuid>
+              cr <bare-uuid>              (Claude Code)
+              cr codex resume <uuid>      (Codex)
+              cr codex fork <uuid>
+              cr <rollout-...>            (Codex, full session id)
     """
     args = list(argv)
+    is_codex = False
+    verb = "resume"
     if args and args[0] == "claude":
         args.pop(0)
+    elif args and args[0] == "codex":
+        is_codex = True
+        args.pop(0)
+        if args and args[0] in ("resume", "fork"):
+            verb = args.pop(0)
 
     session_id = None
     extra = []
@@ -504,17 +534,19 @@ def _parse_resume_args(argv: list[str]) -> tuple[str | None, list[str]]:
         if arg == "--resume" and i + 1 < len(args):
             session_id = args[i + 1]
             skip_next = True
-        elif session_id is None and UUID_RE.match(arg):
+        elif session_id is None and (UUID_RE.match(arg) or arg.startswith("rollout-")):
             session_id = arg
         else:
             extra.append(arg)
 
-    return session_id, extra
+    if session_id and session_id.startswith("rollout-"):
+        is_codex = True
+    return session_id, extra, is_codex, verb
 
 
 def _resume_from_paste(argv: list[str]):
-    """cr claude --resume <id> [flags] — find cwd, add defaults, show proof, launch."""
-    session_id, extra_flags = _parse_resume_args(argv)
+    """cr <claude|codex resume> <id> [flags] — find cwd, add defaults, show proof, launch."""
+    session_id, extra_flags, is_codex, verb = _parse_resume_args(argv)
 
     if session_id is None:
         print(f"  \033[31m✗ No session ID found in: {' '.join(argv)}\033[0m")
@@ -523,28 +555,39 @@ def _resume_from_paste(argv: list[str]):
     print()
     print(f"  🔍 Searching for session {session_id}...")
 
-    project_path = _find_session_project(session_id)
-    if project_path is None:
-        print(f"  \033[31m✗ Session not found in any project directory\033[0m")
-        sys.exit(1)
+    if is_codex:
+        from claude_session_commons.codex import codex_session_uuid
 
-    if not os.path.isdir(project_path):
-        print(f"  \033[31m✗ Resolved path does not exist: {project_path}\033[0m")
-        sys.exit(1)
-
-    # Build command: always ensure defaults
-    cmd = ["claude", "--resume", session_id]
-    if "--dangerously-skip-permissions" not in extra_flags:
-        cmd.append("--dangerously-skip-permissions")
-    if "--enable-auto-mode" not in extra_flags:
-        cmd.append("--enable-auto-mode")
-    cmd.extend(extra_flags)
+        uuid = codex_session_uuid(session_id)
+        # Codex resumes by UUID regardless of cwd, but it operates in the
+        # working dir — cd to the recorded cwd when we can find it.
+        project_path = _find_codex_project(session_id)
+        cmd = ["codex", verb, uuid, *extra_flags]
+        binary = "codex"
+        title = "cr — Codex Resume"
+    else:
+        project_path = _find_session_project(session_id)
+        if project_path is None:
+            print(f"  \033[31m✗ Session not found in any project directory\033[0m")
+            sys.exit(1)
+        if not os.path.isdir(project_path):
+            print(f"  \033[31m✗ Resolved path does not exist: {project_path}\033[0m")
+            sys.exit(1)
+        cmd = ["claude", "--resume", session_id]
+        if "--dangerously-skip-permissions" not in extra_flags:
+            cmd.append("--dangerously-skip-permissions")
+        if "--enable-auto-mode" not in extra_flags:
+            cmd.append("--enable-auto-mode")
+        cmd.extend(extra_flags)
+        binary = "claude"
+        title = "cr — Claude Resume"
 
     cmd_str = " ".join(cmd)
-    project_name = os.path.basename(project_path)
+    cwd_display = project_path or "(current dir — cwd not recorded)"
+    project_name = os.path.basename(project_path) if project_path else "current dir"
 
     print(f"  \033[32m✓ Found!\033[0m")
-    print(f"  \033[90mResolved cwd: {project_path}\033[0m")
+    print(f"  \033[90mResolved cwd: {cwd_display}\033[0m")
     print()
     print(f"  \033[36m→\033[0m Resuming in \033[1m{project_name}\033[0m")
     print(f"  \033[90m{cmd_str}\033[0m")
@@ -553,17 +596,18 @@ def _resume_from_paste(argv: list[str]):
     # macOS dialog — visible proof outside the TUI
     dialog_msg = (
         f"✓ Session: {session_id[:8]}…\\n"
-        f"📂 cwd: {project_path}\\n\\n"
+        f"📂 cwd: {cwd_display}\\n\\n"
         f"{cmd_str}"
     )
     subprocess.Popen([
         "osascript", "-e",
         f'tell application "System Events" to display dialog "{dialog_msg}" '
-        f'with title "cr — Claude Resume" buttons {{"OK"}} default button "OK" giving up after 5'
+        f'with title "{title}" buttons {{"OK"}} default button "OK" giving up after 5'
     ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-    os.chdir(project_path)
-    os.execvp("claude", cmd)
+    if project_path and os.path.isdir(project_path):
+        os.chdir(project_path)
+    os.execvp(binary, cmd)
 
 
 def main():
@@ -571,7 +615,8 @@ def main():
     if len(sys.argv) > 1 and (
         "--resume" in sys.argv
         or (len(sys.argv) == 2 and UUID_RE.match(sys.argv[1]))
-        or (sys.argv[1] == "claude")
+        or sys.argv[1] in ("claude", "codex")
+        or (len(sys.argv) == 2 and sys.argv[1].startswith("rollout-"))
     ):
         _resume_from_paste(sys.argv[1:])
         sys.exit(0)

--- a/resume_resume/mcp_server.py
+++ b/resume_resume/mcp_server.py
@@ -28,6 +28,7 @@ from .sessions import (
     PROJECTS_DIR,
 )
 from claude_session_commons import decode_project_path
+from claude_session_commons.codex import CODEX_SESSIONS_DIR, _read_codex_cwd
 from .summarize import summarize_quick, summarize_deep, summarize_insight, auto_tier
 from .progress import progress
 from .search_index import HOT_WINDOW_SECONDS
@@ -42,6 +43,10 @@ _cache = SessionCache()
 
 _TRUNC = 300  # max chars per message/field
 _UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+# Codex CLI session ids look like rollout-<ISO-ts>-<uuid>. Accept those too.
+# Kept strict (only word chars, hyphens, colons) to preserve glob-injection
+# safety — no '*', '?', '[', ']', or path separators can reach a glob pattern.
+_CODEX_ID_RE = re.compile(r"rollout-[0-9A-Za-z:\-]+")
 
 # Cached wrapper for find_all_sessions — the shared bottleneck across
 # search_sessions, dirty_repos, and boot_up. Each call scans the filesystem
@@ -180,19 +185,37 @@ def _summary_valid(summary: dict) -> bool:
 
 
 def _find_session(session_id: str) -> dict | None:
-    """Find a session by targeted glob — O(1) dirs, not O(N) sessions."""
-    # Validate UUID format to prevent glob injection (* ? [] etc)
-    if not _UUID_RE.fullmatch(session_id):
+    """Find a session by targeted glob — O(dirs), not O(N) sessions.
+
+    Resolves both Claude-Code sessions (~/.claude/projects/*/<uuid>.jsonl)
+    and Codex CLI sessions (~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl).
+    The codex tree is date-partitioned, so a recursive glob on the id stays
+    O(date dirs) rather than scanning every session file.
+    """
+    is_codex = bool(_CODEX_ID_RE.fullmatch(session_id))
+    # Validate id format to prevent glob injection (* ? [] / etc). Only bare
+    # UUIDs or rollout-* ids reach a glob pattern.
+    if not is_codex and not _UUID_RE.fullmatch(session_id):
         return None
-    matches = list(PROJECTS_DIR.glob(f"*/{session_id}.jsonl"))
+
+    if is_codex:
+        matches = list(CODEX_SESSIONS_DIR.glob(f"**/{session_id}.jsonl"))
+    else:
+        matches = list(PROJECTS_DIR.glob(f"*/{session_id}.jsonl"))
     if not matches:
         return None
     f = matches[0]
     stat = f.stat()
+    if is_codex:
+        # Match how scan_codex_sessions labels project_dir: the cwd recorded
+        # in the line-1 session_meta payload.
+        project_dir = _read_codex_cwd(f)
+    else:
+        project_dir = decode_project_path(f.parent.name)
     return {
         "file": f,
         "session_id": session_id,
-        "project_dir": decode_project_path(f.parent.name),
+        "project_dir": project_dir,
         "mtime": stat.st_mtime,
         "size": stat.st_size,
     }
@@ -611,7 +634,7 @@ def read_session(
     limit = max(1, min(limit, 30))
     session = _find_session(session_id)
     if session is None:
-        return {"error": f"Session {session_id[:36]} not found"}
+        return {"error": f"Session {session_id} not found"}
 
     result = _read_messages(session["file"], keyword, limit)
     result["id"] = session_id
@@ -758,7 +781,7 @@ def session_summary(session_id: str, force_regenerate: bool = False,
     """
     session = _find_session(session_id)
     if session is None:
-        return {"error": f"Session {session_id[:36]} not found"}
+        return {"error": f"Session {session_id} not found"}
 
     session_file = session["file"]
     ck = _cache.cache_key(session_file)
@@ -1459,7 +1482,7 @@ def resume_in_terminal(session_id: str, fork: bool = False) -> dict:
     """
     session = _find_session(session_id)
     if session is None:
-        return {"error": f"Session {session_id[:36]} not found"}
+        return {"error": f"Session {session_id} not found"}
 
     project_dir = session["project_dir"]
     title = _get_title(session_id, session["file"]) or project_dir
@@ -1503,7 +1526,7 @@ def merge_context(
     """
     session = _find_session(session_id)
     if session is None:
-        return {"error": f"Session {session_id[:36]} not found"}
+        return {"error": f"Session {session_id} not found"}
 
     message_limit = max(2, min(message_limit, 20))
     project = shorten_path(session["project_dir"])
@@ -1663,7 +1686,7 @@ def session_timeline(
     """
     session = _find_session(session_id)
     if session is None:
-        return {"error": f"Session {session_id[:36]} not found"}
+        return {"error": f"Session {session_id} not found"}
 
     limit = max(10, min(limit, 200))
     needs_full_scan = focus == "even" or after or before
@@ -1921,7 +1944,7 @@ def session_thread(session_id: str) -> dict:
     """
     session = _find_session(session_id)
     if session is None:
-        return {"error": f"Session {session_id[:36]} not found"}
+        return {"error": f"Session {session_id} not found"}
 
     bookmarks_dir = Path.home() / ".claude" / "bookmarks"
     all_bookmarks = {}

--- a/resume_resume/mcp_server.py
+++ b/resume_resume/mcp_server.py
@@ -28,7 +28,7 @@ from .sessions import (
     PROJECTS_DIR,
 )
 from claude_session_commons import decode_project_path
-from claude_session_commons.codex import CODEX_SESSIONS_DIR, _read_codex_cwd
+from claude_session_commons.codex import CODEX_SESSIONS_DIR, _read_codex_cwd, session_tool
 from .summarize import summarize_quick, summarize_deep, summarize_insight, auto_tier
 from .progress import progress
 from .search_index import HOT_WINDOW_SECONDS
@@ -263,6 +263,7 @@ def _get_title(session_id: str, session_file: Path) -> str:
     return summary.get("title", "") if isinstance(summary, dict) else ""
 
 
+from .session_utils import resume_command
 from .session_utils import session_duration_hours as _session_duration_hours
 
 
@@ -582,6 +583,8 @@ def search_sessions(query: str, limit: int = 10, include_automated: bool = False
         })
 
     results = hot_results + cold_results
+    for item in results:
+        item["tool"] = session_tool(item["id"])  # "claude" | "codex"
 
     p.update(f"{len(hot_results)} hot + {len(cold_results)} indexed results", icon="done")
 
@@ -662,6 +665,26 @@ def _read_messages(session_file: Path, keyword: str, limit: int) -> dict:
                 if not isinstance(entry, dict):
                     continue
                 entry_type = entry.get("type")
+
+                # Codex schema: event_msg with payload.{user_message,agent_message}.
+                # Map to the same {role, text} shape as Claude user/assistant entries
+                # so cross-tool merge_context works on Codex sessions too.
+                if entry_type == "event_msg":
+                    payload = entry.get("payload") or {}
+                    ptype = payload.get("type")
+                    if ptype == "user_message":
+                        role, content = "user", payload.get("message", "")
+                    elif ptype == "agent_message":
+                        role, content = "assistant", payload.get("message", "")
+                    else:
+                        continue
+                    if not isinstance(content, str) or not content.strip():
+                        continue
+                    if keyword_lower and keyword_lower not in content.lower():
+                        continue
+                    messages.append({"role": role, "text": _trunc(content)})
+                    continue
+
                 if entry_type not in ("user", "assistant"):
                     continue
 
@@ -1487,9 +1510,7 @@ def resume_in_terminal(session_id: str, fork: bool = False) -> dict:
     project_dir = session["project_dir"]
     title = _get_title(session_id, session["file"]) or project_dir
 
-    cmd = f"claude --resume {session_id}"
-    if fork:
-        cmd += " --fork-session"
+    cmd = resume_command(session_id, fork=fork)
 
     err = _launch_terminal(project_dir, cmd)
     if err:

--- a/resume_resume/mcp_server.py
+++ b/resume_resume/mcp_server.py
@@ -135,6 +135,30 @@ def _hot_sessions(window_seconds: int = HOT_WINDOW_SECONDS) -> list[dict]:
     return sessions
 
 
+# ponytail: 6h freshness window. A session newer than the 30-min hot window but
+# not yet in the daemon's append-only SessionIndex (and therefore not in the
+# cold FTS index either) is invisible to both search tiers — the gap that hid
+# the same-day "nevereatalone" codex session. _fresh_sessions closes it with a
+# real filesystem scan (the cached find_all_sessions, which DOES discover
+# ~/.codex/sessions), capped so the supplemental live scan stays bounded.
+_FRESH_WINDOW_SECONDS = 6 * 60 * 60
+
+
+def _fresh_sessions(cutoff_after: float = 0.0) -> list[dict]:
+    """Recently-modified sessions from the filesystem, regardless of index state.
+
+    Catches sessions written but not yet appended to SessionIndex / ingested
+    into the cold index. Bounded by _FRESH_WINDOW_SECONDS and capped at 200 so
+    a search never turns into an unbounded scan of every fresh file.
+    """
+    floor = time.time() - _FRESH_WINDOW_SECONDS
+    if cutoff_after:
+        floor = max(floor, cutoff_after)
+    fresh = [s for s in _find_all_sessions_cached() if s["mtime"] >= floor]
+    fresh.sort(key=lambda s: s["mtime"], reverse=True)
+    return fresh[:200]  # ponytail: cap supplemental scan
+
+
 def _summary_valid(summary: dict) -> bool:
     """Reject cached summaries that are garbage (XML blobs, fragments, etc.)."""
     if not isinstance(summary, dict):
@@ -437,8 +461,17 @@ def search_sessions(query: str, limit: int = 10, include_automated: bool = False
     if hours > 0:
         cutoff = now - hours * 3600
 
-    # Hot path: only sessions touched in the last 30 minutes are scanned live.
-    hot_sessions = _hot_sessions()
+    # Hot path: sessions touched in the last 30 minutes are scanned live. We
+    # also fold in fresh-but-unindexed sessions (newer than the hot window but
+    # not yet in the daemon index or cold FTS) so same-day sessions are never
+    # invisible while waiting for a background ingestion pass.
+    hot_sessions = list(_hot_sessions())
+    seen_ids = {s["session_id"] for s in hot_sessions}
+    for s in _fresh_sessions(cutoff_after=cutoff):
+        if s["session_id"] not in seen_ids:
+            hot_sessions.append(s)
+            seen_ids.add(s["session_id"])
+
     if cutoff:
         hot_sessions = [s for s in hot_sessions if s["mtime"] >= cutoff]
 
@@ -505,8 +538,14 @@ def search_sessions(query: str, limit: int = 10, include_automated: bool = False
             project=project,
         )
 
+    # The live scan now reaches back further than the cold cutoff, so a fresh
+    # session can surface in both tiers. Prefer the hot-live hit and drop the
+    # cold duplicate.
+    hot_ids = {r["id"] for r in hot_results}
     cold_results = []
     for row in cold_rows:
+        if row["session_id"] in hot_ids:
+            continue
         cold_results.append({
             "id": row["session_id"],
             "project": shorten_path(row.get("project_dir") or ""),

--- a/resume_resume/resume_card.py
+++ b/resume_resume/resume_card.py
@@ -22,6 +22,7 @@ from claude_session_commons import decode_project_path
 
 from .sessions import PROJECTS_DIR, SessionCache, relative_time, shorten_path
 from .search_index import recent_candidates
+from .session_utils import resume_command
 
 UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
 
@@ -288,7 +289,7 @@ def build_card(
     title = str(summary.get("title") or "").splitlines()
     title_text = title[0].strip() if title else ""
     project_dir = str(session.get("project_dir") or "")
-    command = f"claude --resume {session['session_id']}"
+    command = resume_command(session["session_id"])
 
     return {
         "session_id": session["session_id"],

--- a/resume_resume/search_index.py
+++ b/resume_resume/search_index.py
@@ -266,7 +266,10 @@ def _fts_query(query: str) -> str:
     remaining = re.sub(r'"[^"]*"', "", query)
     words = [t.replace('"', "") for t in remaining.lower().split() if t.strip()]
     tokens = [t for t in [*phrases, *words] if t]
-    return " AND ".join(f'"{t}"' for t in tokens)
+    # Join with OR so a query is tolerant of missing words: a session need not
+    # contain every term to match. bm25() ranking (see search()) naturally floats
+    # sessions matching more query terms to the top.
+    return " OR ".join(f'"{t}"' for t in tokens)
 
 
 def search(

--- a/resume_resume/session_utils.py
+++ b/resume_resume/session_utils.py
@@ -11,6 +11,38 @@ from datetime import datetime
 from pathlib import Path
 
 
+def resume_command(
+    session_id: str,
+    *,
+    fork: bool = False,
+    skip_permissions: bool = False,
+) -> str:
+    """Build the CLI command to resume (or fork) a session, by source.
+
+    Claude Code → ``claude --resume <id>`` (``--fork-session`` to fork).
+    Codex CLI   → ``codex resume <uuid>`` (``codex fork <uuid>`` to fork),
+    where the UUID is extracted from the rollout filename stem.
+
+    ``skip_permissions`` only applies to Claude Code; Codex has no equivalent
+    flag and ignores it.
+    """
+    from claude_session_commons.codex import (
+        codex_session_uuid,
+        is_codex_session_id,
+    )
+
+    if is_codex_session_id(session_id):
+        verb = "fork" if fork else "resume"
+        return f"codex {verb} {codex_session_uuid(session_id)}"
+
+    cmd = f"claude --resume {session_id}"
+    if fork:
+        cmd += " --fork-session"
+    if skip_permissions:
+        cmd += " --dangerously-skip-permissions"
+    return cmd
+
+
 def filter_automated(sessions: list[dict], cache_index: dict) -> list[dict]:
     """Remove sessions classified as 'automated' by the ML classifier.
 

--- a/tests/test_codex_crosstool.py
+++ b/tests/test_codex_crosstool.py
@@ -1,0 +1,42 @@
+"""Cross-tool support: Codex messages parse for merge_context, sessions label by tool."""
+
+from claude_session_commons.codex import session_tool
+from resume_resume import mcp_server as ms
+
+CODEX_ROLLOUT = (
+    '{"timestamp":"2026-06-12T19:00:30Z","type":"session_meta",'
+    '"payload":{"id":"019ebc0c-9f4f-7362-9d26-fb071dfeecbe","cwd":"/tmp/demo"}}\n'
+    '{"timestamp":"2026-06-12T19:01:00Z","type":"event_msg",'
+    '"payload":{"type":"user_message","message":"research the auth token refresh bug"}}\n'
+    '{"timestamp":"2026-06-12T19:01:30Z","type":"event_msg",'
+    '"payload":{"type":"agent_message","message":"the refresh uses a 24h presigned url"}}\n'
+    '{"timestamp":"2026-06-12T19:02:00Z","type":"response_item",'
+    '"payload":{"type":"function_call","name":"exec_command","arguments":"{}"}}\n'
+)
+
+
+def test_session_tool_labels_by_source():
+    assert session_tool("rollout-2026-06-12T08-36-57-019ebc0c-9f4f-7362-9d26-fb071dfeecbe") == "codex"
+    assert session_tool("ddf7fc98-6c93-40c8-9444-503d8a716dbf") == "claude"
+
+
+def test_read_messages_handles_codex_schema(tmp_path):
+    f = tmp_path / "rollout-2026-06-12T19-00-30-019ebc0c-9f4f-7362-9d26-fb071dfeecbe.jsonl"
+    f.write_text(CODEX_ROLLOUT)
+
+    out = ms._read_messages(f, "", 6)
+    roles = [m["role"] for m in out["messages"]]
+    texts = " ".join(m["text"] for m in out["messages"])
+
+    assert roles == ["user", "assistant"], out
+    assert "auth token refresh" in texts
+    assert "presigned url" in texts
+
+
+def test_read_messages_codex_keyword_filter(tmp_path):
+    f = tmp_path / "rollout-x-019ebc0c-9f4f-7362-9d26-fb071dfeecbe.jsonl"
+    f.write_text(CODEX_ROLLOUT)
+
+    out = ms._read_messages(f, "presigned", 6)
+    assert len(out["messages"]) == 1
+    assert out["messages"][0]["role"] == "assistant"

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -1,0 +1,80 @@
+"""Tests for _find_session — resolves both Claude-Code and Codex sessions.
+
+Regression coverage for the bug where search_sessions surfaced Codex
+`rollout-*` ids but _find_session (UUID-gated, ~/.claude/projects-only glob)
+returned None for them, breaking read_session / session_summary / resume etc.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from resume_resume import mcp_server as ms
+
+
+CLAUDE_UUID = "019ed161-140f-7791-872c-c752174d4a55"
+CODEX_ID = "rollout-2026-06-16T12-01-00-019ed161-140f-7791-872c-c752174d4a55"
+EXPECTED_KEYS = {"file", "session_id", "project_dir", "mtime", "size"}
+
+
+@pytest.fixture
+def session_roots(tmp_path, monkeypatch):
+    """Mirror the real on-disk layout under a temp dir and point the
+    module's PROJECTS_DIR / CODEX_SESSIONS_DIR at it."""
+    # Claude: ~/.claude/projects/<encoded>/<uuid>.jsonl
+    projects = tmp_path / "projects"
+    proj_dir = projects / "-Users-dshanklinbv-repos-eidos-agi-resume-resume"
+    proj_dir.mkdir(parents=True)
+    claude_file = proj_dir / f"{CLAUDE_UUID}.jsonl"
+    claude_file.write_text(json.dumps({"type": "user", "message": {"content": "hi"}}) + "\n")
+
+    # Codex: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+    codex_root = tmp_path / "codex"
+    day_dir = codex_root / "2026" / "06" / "16"
+    day_dir.mkdir(parents=True)
+    codex_file = day_dir / f"{CODEX_ID}.jsonl"
+    codex_file.write_text(
+        json.dumps({"type": "session_meta", "payload": {"cwd": "/Users/dshanklinbv/repos-jetta-operating"}}) + "\n"
+    )
+
+    monkeypatch.setattr(ms, "PROJECTS_DIR", projects)
+    monkeypatch.setattr(ms, "CODEX_SESSIONS_DIR", codex_root)
+    return {"claude": claude_file, "codex": codex_file}
+
+
+def test_codex_rollout_id_resolves(session_roots):
+    result = ms._find_session(CODEX_ID)
+    assert result is not None, "Codex rollout id should resolve"
+    assert set(result.keys()) == EXPECTED_KEYS
+    assert result["file"] == session_roots["codex"]
+    assert result["session_id"] == CODEX_ID
+    # project_dir derived from the session_meta cwd, matching scan_codex_sessions
+    assert result["project_dir"] == "/Users/dshanklinbv/repos-jetta-operating"
+    assert result["size"] > 0
+
+
+def test_normal_uuid_still_resolves(session_roots):
+    result = ms._find_session(CLAUDE_UUID)
+    assert result is not None, "Claude UUID should still resolve"
+    assert set(result.keys()) == EXPECTED_KEYS
+    assert result["file"] == session_roots["claude"]
+    assert result["session_id"] == CLAUDE_UUID
+    assert "resume-resume" in result["project_dir"]
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "*",
+        "rollout-*",
+        "abc?def",
+        "id[0-9]",
+        "../../etc/passwd",
+        "foo/bar",
+        "rollout-2026/06/16",
+    ],
+)
+def test_glob_injection_rejected(session_roots, bad_id):
+    assert ms._find_session(bad_id) is None

--- a/tests/test_fts_query.py
+++ b/tests/test_fts_query.py
@@ -1,0 +1,26 @@
+"""Tests for _fts_query token-to-FTS5 translation.
+
+Regression for the intolerant-search bug: a multi-word query used to join
+tokens with AND, so a session matching 3 of 4 words returned zero results.
+Tokens are now joined with OR (tolerant), and bm25() ranking floats the
+sessions matching more terms to the top.
+"""
+from resume_resume.search_index import _fts_query
+
+
+def test_multi_word_query_is_or_joined():
+    fts = _fts_query("eat alone dinner")
+    assert fts == '"eat" OR "alone" OR "dinner"'
+    assert " AND " not in fts
+
+
+def test_single_token_has_no_join():
+    fts = _fts_query("dinner")
+    assert fts == '"dinner"'
+    assert " OR " not in fts and " AND " not in fts
+
+
+def test_empty_query_returns_empty_string():
+    # Callers rely on "" to skip the search entirely.
+    assert _fts_query("") == ""
+    assert _fts_query("   ") == ""

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -1,0 +1,68 @@
+"""Regression for the index-freshness gap.
+
+A session written ~90 minutes ago is older than the 30-min hot window, but if
+it hasn't been appended to the daemon SessionIndex yet, it's also absent from
+the cold FTS index. It used to fall into a gap and be invisible to keyword
+search — this is exactly how the same-day "nevereatalone" codex session
+disappeared.
+
+search_sessions now supplements the live hot scan with a bounded filesystem
+scan of fresh-but-unindexed sessions, so a same-day session is findable by
+keyword without waiting for a background ingestion pass.
+"""
+
+from __future__ import annotations
+
+import time
+
+from resume_resume import mcp_server as ms
+
+
+def test_fresh_unindexed_session_is_findable(tmp_path, monkeypatch):
+    # A session written 90 minutes ago: past the 30-min hot window, but well
+    # within the 6h freshness window. Crucially, NOT in the daemon index.
+    mtime = time.time() - 90 * 60
+    session_file = tmp_path / "rollout-fresh-nevereatalone.jsonl"
+    session_file.write_text(
+        '{"type":"message","role":"user","content":"let us talk about nevereatalone"}\n'
+    )
+    session_file.touch()
+    import os as _os
+    _os.utime(session_file, (mtime, mtime))
+
+    fresh_session = {
+        "session_id": "fresh-nevereatalone",
+        "file": session_file,
+        "project_dir": "/Users/test/repos/demo",
+        "mtime": mtime,
+        "size": session_file.stat().st_size,
+    }
+
+    # Hot scan (daemon index) does NOT know about this session — the gap.
+    monkeypatch.setattr(ms, "_hot_sessions", lambda *a, **k: [])
+    # Filesystem scan DOES discover it (as find_all_sessions does for codex).
+    monkeypatch.setattr(ms, "_find_all_sessions_cached", lambda: [fresh_session])
+    # Cold index has nothing for it.
+    monkeypatch.setattr(ms, "search_cold_index", lambda *a, **k: [])
+
+    result = ms.search_sessions.fn("nevereatalone", limit=10)
+
+    ids = [item["id"] for item in result["items"]]
+    assert "fresh-nevereatalone" in ids, result
+    hit = next(i for i in result["items"] if i["id"] == "fresh-nevereatalone")
+    assert hit["source"] == "hot-live"
+    assert hit["hits"] >= 1
+
+
+def test_fresh_sessions_respects_window_and_cap(tmp_path, monkeypatch):
+    # Older than the freshness window -> excluded; fresh -> included.
+    old = {"session_id": "too-old", "file": tmp_path / "a", "project_dir": "",
+           "mtime": time.time() - ms._FRESH_WINDOW_SECONDS - 60, "size": 200}
+    new = {"session_id": "fresh", "file": tmp_path / "b", "project_dir": "",
+           "mtime": time.time() - 60, "size": 200}
+    monkeypatch.setattr(ms, "_find_all_sessions_cached", lambda: [old, new])
+
+    out = ms._fresh_sessions()
+    ids = {s["session_id"] for s in out}
+    assert "fresh" in ids
+    assert "too-old" not in ids

--- a/tests/test_resume_command.py
+++ b/tests/test_resume_command.py
@@ -1,0 +1,43 @@
+"""resume_command builds the right CLI per source (Claude Code vs Codex)."""
+
+from claude_session_commons.codex import codex_session_uuid, is_codex_session_id
+from resume_resume.session_utils import resume_command
+
+CODEX_ID = "rollout-2026-06-12T08-36-57-019ebc0c-9f4f-7362-9d26-fb071dfeecbe"
+CODEX_UUID = "019ebc0c-9f4f-7362-9d26-fb071dfeecbe"
+CLAUDE_ID = "ddf7fc98-6c93-40c8-9444-503d8a716dbf"
+
+
+def test_codex_uuid_extracted_from_rollout_stem():
+    assert is_codex_session_id(CODEX_ID)
+    assert not is_codex_session_id(CLAUDE_ID)
+    assert codex_session_uuid(CODEX_ID) == CODEX_UUID
+
+
+def test_codex_resume_and_fork():
+    assert resume_command(CODEX_ID) == f"codex resume {CODEX_UUID}"
+    assert resume_command(CODEX_ID, fork=True) == f"codex fork {CODEX_UUID}"
+    # Codex has no skip-permissions flag — it's ignored, not appended.
+    assert resume_command(CODEX_ID, skip_permissions=True) == f"codex resume {CODEX_UUID}"
+
+
+def test_claude_resume_and_fork():
+    assert resume_command(CLAUDE_ID) == f"claude --resume {CLAUDE_ID}"
+    assert resume_command(CLAUDE_ID, fork=True) == f"claude --resume {CLAUDE_ID} --fork-session"
+    assert resume_command(CLAUDE_ID, skip_permissions=True) == (
+        f"claude --resume {CLAUDE_ID} --dangerously-skip-permissions"
+    )
+
+
+def test_cr_paste_parsing_covers_both_tools():
+    from resume_resume.cli import _parse_resume_args
+
+    assert _parse_resume_args(["claude", "--resume", CLAUDE_ID, "--model", "opus"]) == (
+        CLAUDE_ID, ["--model", "opus"], False, "resume")
+    assert _parse_resume_args(["--resume", CLAUDE_ID]) == (CLAUDE_ID, [], False, "resume")
+    assert _parse_resume_args([CLAUDE_ID]) == (CLAUDE_ID, [], False, "resume")
+    assert _parse_resume_args(["codex", "resume", CODEX_UUID]) == (
+        CODEX_UUID, [], True, "resume")
+    assert _parse_resume_args(["codex", "fork", CODEX_UUID]) == (CODEX_UUID, [], True, "fork")
+    # A bare full rollout id is recognized as Codex.
+    assert _parse_resume_args([CODEX_ID]) == (CODEX_ID, [], True, "resume")


### PR DESCRIPTION
Makes Codex a first-class citizen across the whole surface: **find → read → resume → merge**. Builds on `ea44537` (`_find_session` resolves Codex rollouts).

## What
- **`session_utils.resume_command()`** — single source of truth for resume commands. Claude → `claude --resume <id>`; Codex → `codex resume <uuid>`. Routed through `resume_in_terminal`, the `resume_cmd` field, and resume cards.
- **`cli.py`** — `cr` handles Codex paste forms (`cr codex resume/fork <uuid>`, bare `cr <rollout-id>`); `_find_codex_project` reads the recorded cwd and cd's there.
- **`mcp_server._read_messages`** — schema-aware; maps Codex `event_msg` user/agent messages to `{role,text}`, so **`merge_context` works cross-tool** (bridge Codex research into a Claude session).
- **Source labeling** — `search_sessions` items carry a `tool` field (`claude`|`codex`).

## Tests
`test_resume_command.py`, `test_codex_crosstool.py` (CI-safe synthetic fixtures). Full suite **139 green**.

## Version
0.5.5 → **0.6.0**; requires `claude-session-commons>=0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)