### PR TITLE
fix: relax claude-session-commons pin to >=0.1.0 (unblock CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
-    "claude-session-commons>=0.2.0",
+    "claude-session-commons>=0.1.0",
     "textual>=0.40",
     "numpy",
     "fastmcp>=2.0",


### PR DESCRIPTION
The `>=0.2.0` pin was stale (0.2.0 never published to PyPI), so CI's `pip install -e .` failed and the test job has been red since before the paste-find work. The code runs on 0.1.0 — every imported symbol resolves and all 142 tests pass against it locally. This lets CI install the published 0.1.0 and run the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)