### PR TITLE
fix(search): multi-host seams — catalog = resolve = label (MS-0002)

### DIFF
--- a/resume_resume/mcp_server.py
+++ b/resume_resume/mcp_server.py
@@ -31,6 +31,10 @@ from claude_session_commons import decode_project_path
 from claude_session_commons.codex import (
     CODEX_SESSIONS_DIR,
     _read_codex_cwd,
+)
+from .session_utils import (
+    GROK_SESSIONS_DIR,
+    find_grok_session_file,
     session_tool,
 )
 from .summarize import summarize_quick, summarize_deep, summarize_insight, auto_tier
@@ -205,10 +209,14 @@ def _summary_valid(summary: dict) -> bool:
 def _find_session(session_id: str) -> dict | None:
     """Find a session by targeted glob — O(dirs), not O(N) sessions.
 
-    Resolves both Claude-Code sessions (~/.claude/projects/*/<uuid>.jsonl)
-    and Codex CLI sessions (~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl).
-    The codex tree is date-partitioned, so a recursive glob on the id stays
-    O(date dirs) rather than scanning every session file.
+    Resolves:
+      - Claude Code → ~/.claude/projects/*/<uuid>.jsonl
+      - Codex CLI   → ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+      - Grok Build  → ~/.grok/sessions/<encoded-cwd>/<id>/chat_history.jsonl
+
+    Codex tree is date-partitioned, so a recursive glob on the id stays
+    O(date dirs) rather than scanning every session file. Grok is one-level
+    under the sessions root (TASK-0026 / MS-0002).
     """
     is_codex = bool(_CODEX_ID_RE.fullmatch(session_id))
     # Validate id format to prevent glob injection (* ? [] / etc). Only bare
@@ -218,25 +226,45 @@ def _find_session(session_id: str) -> dict | None:
 
     if is_codex:
         matches = list(CODEX_SESSIONS_DIR.glob(f"**/{session_id}.jsonl"))
-    else:
-        matches = list(PROJECTS_DIR.glob(f"*/{session_id}.jsonl"))
-    if not matches:
-        return None
-    f = matches[0]
-    stat = f.stat()
-    if is_codex:
-        # Match how scan_codex_sessions labels project_dir: the cwd recorded
-        # in the line-1 session_meta payload.
-        project_dir = _read_codex_cwd(f)
-    else:
-        project_dir = decode_project_path(f.parent.name)
-    return {
-        "file": f,
-        "session_id": session_id,
-        "project_dir": project_dir,
-        "mtime": stat.st_mtime,
-        "size": stat.st_size,
-    }
+        if not matches:
+            return None
+        f = matches[0]
+        stat = f.stat()
+        return {
+            "file": f,
+            "session_id": session_id,
+            "project_dir": _read_codex_cwd(f),
+            "mtime": stat.st_mtime,
+            "size": stat.st_size,
+        }
+
+    # Claude Code first (historical default for bare UUIDs)
+    matches = list(PROJECTS_DIR.glob(f"*/{session_id}.jsonl"))
+    if matches:
+        f = matches[0]
+        stat = f.stat()
+        return {
+            "file": f,
+            "session_id": session_id,
+            "project_dir": decode_project_path(f.parent.name),
+            "mtime": stat.st_mtime,
+            "size": stat.st_size,
+        }
+
+    # Grok Build: ~/.grok/sessions/<encoded-cwd>/<id>/chat_history.jsonl
+    grok = find_grok_session_file(session_id, grok_root=GROK_SESSIONS_DIR)
+    if grok is not None:
+        f, project_dir = grok
+        stat = f.stat()
+        return {
+            "file": f,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "mtime": stat.st_mtime,
+            "size": stat.st_size,
+        }
+
+    return None
 
 
 def _trunc(text: str, limit: int = _TRUNC) -> str:
@@ -468,25 +496,27 @@ def search_sessions(
     include_automated: bool = False,
     hours: int = 0,
     project: str = "",
+    tool: str = "",
 ) -> dict:
-    """Search Claude Code sessions by keywords.
+    """Search sessions by keywords (Claude / Codex / Grok).
 
-    Uses a two-tier search path:
-      - live scan for sessions touched in the last 30 minutes
-      - SQLite/FTS cold index for older sessions
+    Two-tier path (MS-0002 TASK-0033):
+      - hot: live scan of recently touched session files (last 30 min + fresh net)
+      - cold: SQLite/FTS summary index for older sessions
 
-    This keeps fresh crash-resume context visible without request-time scans of
-    the full session/summaries directory.
+    Both tiers always run for the full ``limit``. Results are merged and
+    deduped by session_id (prefer hot-live when both match). Hot recency no
+    longer starves cold relevance.
 
     Query syntax:
-      - Multiple words: AND logic (all must appear). "visa mastercard" finds
-        sessions containing BOTH words.
+      - Hot (live bytes): multi-word AND — every term must appear in the file.
+      - Cold (FTS summaries): multi-word OR — bm25 ranks sessions matching more
+        terms higher (tolerant recall; see search_index._fts_query).
       - Quoted phrases: exact match. '"mountain creek"' finds that exact phrase.
       - Single word: standard search.
 
-    Hot results include raw hit counts and snippets. Cold results come from the
-    summary/search-text FTS index and include source="cold-index".
-    Use read_session() to drill into a result. Resume with: claude --resume <id>
+    Hot results include raw hit counts and snippets. Cold results include
+    source="cold-index". Use read_session() to drill in.
 
     Parameters:
       include_automated: If False (default), skip sessions classified as
@@ -497,12 +527,21 @@ def search_sessions(
       project: If non-empty, filter to sessions in projects whose path
         contains this substring. Case-insensitive. "ciso" matches
         /Users/.../repos-aic/ciso. Default "" = search all projects.
+      tool: Optional host filter: "claude" | "codex" | "grok" | "" (all).
     """
     _empty = {"items": [], "count": 0}
     query = query.strip()
     if not query:
         return _empty
     limit = max(1, min(limit, 50))
+    tool_filter = (tool or "").strip().lower()
+    if tool_filter and tool_filter not in ("claude", "codex", "grok", "all"):
+        return {
+            "error": f"Invalid tool filter {tool!r}; use claude|codex|grok|all|\"\"",
+            **_empty,
+        }
+    if tool_filter == "all":
+        tool_filter = ""
 
     # Parse query: support quoted phrases and individual terms
     phrases = re.findall(r'"([^"]+)"', query)
@@ -550,14 +589,13 @@ def search_sessions(
     p.update(f"Live scanning {len(hot_sessions)} hot sessions...", icon="search")
 
     def _check(s):
-        sid = s["session_id"]
         raw = _read_session_bytes(s)
         if raw is None:
             return None
         per_term_counts = []
         for term in terms_bytes:
             c = raw.count(term)
-            if c == 0:
+            if c == 0:  # hot path: AND — any missing term rejects
                 return None
             per_term_counts.append(c)
         total_count = sum(per_term_counts)
@@ -568,19 +606,17 @@ def search_sessions(
     from concurrent.futures import as_completed
 
     hot_matches = []
-    total = len(hot_sessions)
-    checked = 0
 
     if hot_sessions:
         with ThreadPoolExecutor(max_workers=min(8, max(1, len(hot_sessions)))) as pool:
             futures = {pool.submit(_check, s): s for s in hot_sessions}
             for future in as_completed(futures):
-                checked += 1
                 result = future.result()
                 if result is not None:
                     hot_matches.append(result)
 
     hot_matches.sort(key=lambda x: (x[1], x[0]["mtime"]), reverse=True)
+    # Keep full hot match list for merge; cap after merge with cold.
     hot_results = [
         _session_row(
             s,
@@ -591,30 +627,25 @@ def search_sessions(
                 "source": "hot-live",
             },
         )
-        for s, total_count, snippet in hot_matches[:limit]
+        for s, total_count, snippet in hot_matches
     ]
 
-    remaining = max(limit - len(hot_results), 0)
-    cold_rows = []
-    if remaining:
-        p.update("Searching cold SQLite index...", icon="working")
-        cold_rows = search_cold_index(
-            query,
-            limit=remaining,
-            include_automated=include_automated,
-            cutoff_after=cutoff,
-            cutoff_before=hot_cutoff,
-            project=project,
-        )
+    # TASK-0033: always query cold for the full limit (not remaining slots).
+    p.update("Searching cold SQLite index...", icon="working")
+    cold_rows = search_cold_index(
+        query,
+        limit=limit,
+        include_automated=include_automated,
+        cutoff_after=cutoff,
+        cutoff_before=hot_cutoff,
+        project=project,
+    )
 
-    # The live scan now reaches back further than the cold cutoff, so a fresh
-    # session can surface in both tiers. Prefer the hot-live hit and drop the
-    # cold duplicate.
     hot_ids = {r["id"] for r in hot_results}
     cold_results = []
     for row in cold_rows:
         if row["session_id"] in hot_ids:
-            continue
+            continue  # prefer hot-live when both tiers match
         cold_results.append(
             {
                 "id": row["session_id"],
@@ -622,19 +653,48 @@ def search_sessions(
                 "date": datetime.fromtimestamp(row["mtime"]).strftime("%Y-%m-%d %H:%M"),
                 "title": row.get("title") or "",
                 "health": round(float(row.get("score") or 0.0), 0),
-                "score": round(abs(float(row.get("rank") or 0.0)), 3),
+                # Invert bm25 (lower is better) into a 0–100-ish rank score for merge
+                "score": round(
+                    max(0.0, 50.0 - abs(float(row.get("rank") or 0.0))), 3
+                ),
                 "hits": None,
-                "snippet": row.get("state") or "",
+                "snippet": row.get("state") or row.get("title") or "",
                 "source": "cold-index",
             }
         )
 
-    results = hot_results + cold_results
-    for item in results:
-        item["tool"] = session_tool(item["id"])  # "claude" | "codex"
+    # Label hosts, then filter by tool BEFORE limit (TASK-0030) so tool=claude
+    # still fills the limit from cold when hot is Grok noise.
+    for item in hot_results + cold_results:
+        item["tool"] = session_tool(item["id"])  # "claude" | "codex" | "grok"
+    if tool_filter:
+        hot_results = [r for r in hot_results if r.get("tool") == tool_filter]
+        cold_results = [r for r in cold_results if r.get("tool") == tool_filter]
+
+    # TASK-0033 fair merge: reserve cold slots so hot recency cannot monopolize
+    # the full limit when cold has matches (northstar 727d811c vs Grok prompt soup).
+    hot_results.sort(
+        key=lambda r: (float(r.get("score") or 0.0), r.get("date") or ""),
+        reverse=True,
+    )
+    cold_results.sort(
+        key=lambda r: (float(r.get("score") or 0.0), r.get("date") or ""),
+        reverse=True,
+    )
+    if cold_results and hot_results:
+        cold_slots = min(len(cold_results), max(1, limit // 2))
+        hot_slots = limit - cold_slots
+        results = hot_results[:hot_slots] + cold_results[:cold_slots]
+        results.sort(
+            key=lambda r: (float(r.get("score") or 0.0), r.get("date") or ""),
+            reverse=True,
+        )
+    else:
+        results = (hot_results or cold_results)[:limit]
 
     p.update(
-        f"{len(hot_results)} hot + {len(cold_results)} indexed results", icon="done"
+        f"{len(hot_results)} hot + {len(cold_results)} cold → {len(results)} merged",
+        icon="done",
     )
 
     time.sleep(0.1)  # let socket flush before closing
@@ -645,6 +705,8 @@ def search_sessions(
         "count": len(results),
         "hot_window_minutes": int(HOT_WINDOW_SECONDS / 60),
         "cold_index": search_index_status(),
+        "hot_matches": len(hot_results),
+        "cold_matches": len(cold_results),
     }
 
 
@@ -739,10 +801,17 @@ def _read_messages(session_file: Path, keyword: str, limit: int) -> dict:
                 if entry_type not in ("user", "assistant"):
                     continue
 
-                msg = entry.get("message", {})
-                if not isinstance(msg, dict):
+                # Claude Code: content under entry.message.content
+                # Grok Build chat_history.jsonl: content on the entry itself
+                # (type=user|assistant, content=str|list) — MS-0002 TASK-0027
+                msg = entry.get("message")
+                if isinstance(msg, dict) and "content" in msg:
+                    content = msg.get("content", "")
+                elif "content" in entry:
+                    content = entry.get("content", "")
+                else:
                     continue
-                content = msg.get("content", "")
+
                 if isinstance(content, list):
                     texts = []
                     for block in content:
@@ -792,16 +861,18 @@ _RECENT_SESSIONS_CACHE_TTL = (
 
 @mcp.tool()
 def recent_sessions(
-    hours: int = 24, limit: int = 10, project: str = "", include_automated: bool = False
+    hours: int = 24,
+    limit: int = 10,
+    project: str = "",
+    include_automated: bool = False,
+    tool: str = "",
 ) -> dict:
-    """List recently active Claude Code sessions, newest first.
+    """List recently active sessions (Claude / Codex / Grok), newest first.
 
     Use this for: "show me recent sessions", "what sessions ran today".
     Use my_week instead for: "what did I work on this week" (cross-project summary).
     Use healthy_sessions instead for: "which sessions are worth resuming" (value-ranked).
     Use search_sessions instead for: keyword-based search across all sessions.
-
-    Resume any session with: claude --resume <id>
 
     Parameters:
       hours: Lookback window (default 24).
@@ -811,12 +882,23 @@ def recent_sessions(
         /Users/.../repos-aic/ciso. Default "" = all projects.
       include_automated: If False (default), skip sessions classified as
         "automated" by the ML classifier. Same filter as search_sessions.
+      tool: Optional host filter: "claude" | "codex" | "grok" | "" (all).
 
-    Result is cached for 10 seconds per (hours, limit, project, include_automated)
+    Result is cached for 10 seconds per (hours, limit, project, include_automated, tool)
     key so rapid back-to-back calls are free.
     """
     limit = max(1, min(limit, 25))
-    cache_key = (hours, limit, project.lower(), include_automated)
+    tool_filter = (tool or "").strip().lower()
+    if tool_filter == "all":
+        tool_filter = ""
+    if tool_filter and tool_filter not in ("claude", "codex", "grok"):
+        return {
+            "error": f"Invalid tool filter {tool!r}; use claude|codex|grok|all|\"\"",
+            "items": [],
+            "count": 0,
+        }
+
+    cache_key = (hours, limit, project.lower(), include_automated, tool_filter)
     now = time.time()
     cached = _RECENT_SESSIONS_CACHE.get(cache_key)
     if cached and (now - cached["ts"]) < _RECENT_SESSIONS_CACHE_TTL:
@@ -828,7 +910,7 @@ def recent_sessions(
 
     # Fetch enough sessions to have headroom after filtering.
     # Fetching ALL sessions (max_sessions=0) is too expensive under load.
-    fetch_limit = limit * 5 if (project or not include_automated) else limit
+    fetch_limit = limit * 5 if (project or not include_automated or tool_filter) else limit
     sessions = find_recent_sessions(hours, max_sessions=fetch_limit)
 
     if not include_automated:
@@ -843,9 +925,18 @@ def recent_sessions(
             s for s in sessions if project_lower in s.get("project_dir", "").lower()
         ]
 
+    if tool_filter:
+        sessions = [
+            s
+            for s in sessions
+            if session_tool(s.get("session_id", "")) == tool_filter
+        ]
+
     sessions = sessions[:limit]
     ci = _get_cache_index() if not include_automated else None
     items = [_session_row(s, cache_index=ci) for s in sessions]
+    for item in items:
+        item["tool"] = session_tool(item["id"])
     data = {"items": items, "count": len(items), "cached": False}
     _RECENT_SESSIONS_CACHE[cache_key] = {"data": data, "ts": now}
     return data

--- a/resume_resume/mcp_server.py
+++ b/resume_resume/mcp_server.py
@@ -537,7 +537,7 @@ def search_sessions(
     tool_filter = (tool or "").strip().lower()
     if tool_filter and tool_filter not in ("claude", "codex", "grok", "all"):
         return {
-            "error": f"Invalid tool filter {tool!r}; use claude|codex|grok|all|\"\"",
+            "error": f'Invalid tool filter {tool!r}; use claude|codex|grok|all|""',
             **_empty,
         }
     if tool_filter == "all":
@@ -654,9 +654,7 @@ def search_sessions(
                 "title": row.get("title") or "",
                 "health": round(float(row.get("score") or 0.0), 0),
                 # Invert bm25 (lower is better) into a 0–100-ish rank score for merge
-                "score": round(
-                    max(0.0, 50.0 - abs(float(row.get("rank") or 0.0))), 3
-                ),
+                "score": round(max(0.0, 50.0 - abs(float(row.get("rank") or 0.0))), 3),
                 "hits": None,
                 "snippet": row.get("state") or row.get("title") or "",
                 "source": "cold-index",
@@ -893,7 +891,7 @@ def recent_sessions(
         tool_filter = ""
     if tool_filter and tool_filter not in ("claude", "codex", "grok"):
         return {
-            "error": f"Invalid tool filter {tool!r}; use claude|codex|grok|all|\"\"",
+            "error": f'Invalid tool filter {tool!r}; use claude|codex|grok|all|""',
             "items": [],
             "count": 0,
         }
@@ -910,7 +908,9 @@ def recent_sessions(
 
     # Fetch enough sessions to have headroom after filtering.
     # Fetching ALL sessions (max_sessions=0) is too expensive under load.
-    fetch_limit = limit * 5 if (project or not include_automated or tool_filter) else limit
+    fetch_limit = (
+        limit * 5 if (project or not include_automated or tool_filter) else limit
+    )
     sessions = find_recent_sessions(hours, max_sessions=fetch_limit)
 
     if not include_automated:
@@ -927,9 +927,7 @@ def recent_sessions(
 
     if tool_filter:
         sessions = [
-            s
-            for s in sessions
-            if session_tool(s.get("session_id", "")) == tool_filter
+            s for s in sessions if session_tool(s.get("session_id", "")) == tool_filter
         ]
 
     sessions = sessions[:limit]

--- a/resume_resume/search_index.py
+++ b/resume_resume/search_index.py
@@ -113,12 +113,22 @@ def _parse_summary_file(path: Path) -> dict[str, Any] | None:
         return None
 
     meta = _session_meta(path.stem)
+    project_dir = (
+        summary.get("project_dir")
+        or data.get("project_dir")
+        or meta.get("project_dir")
+        or ""
+    )
+    # TASK-0029: never leave project_dir empty when SessionIndex / discovery
+    # can supply it. Also try a cheap filesystem resolve for Claude/Grok.
+    if not project_dir:
+        project_dir = _resolve_project_dir(path.stem) or ""
 
     return {
         "session_id": path.stem,
         "summary_path": str(path),
         "mtime": float(meta.get("mtime") or path.stat().st_mtime),
-        "project_dir": summary.get("project_dir") or meta.get("project_dir") or "",
+        "project_dir": project_dir,
         "classification": data.get("classification") or "",
         "score": float(data.get("resumability_score") or 0.0),
         "title": title,
@@ -126,6 +136,41 @@ def _parse_summary_file(path: Path) -> dict[str, Any] | None:
         "summary_json": json.dumps(summary),
         "body": body,
     }
+
+
+def _resolve_project_dir(session_id: str) -> str:
+    """Best-effort project_dir for a session id when summary meta is empty."""
+    if not session_id:
+        return ""
+    try:
+        from claude_session_commons.paths import decode_project_path
+        from claude_session_commons.discovery import PROJECTS_DIR
+    except Exception:
+        try:
+            from claude_session_commons import decode_project_path
+            from pathlib import Path as _P
+
+            PROJECTS_DIR = _P.home() / ".claude" / "projects"
+        except Exception:
+            return ""
+
+    try:
+        if not session_id.startswith("rollout-"):
+            matches = list(PROJECTS_DIR.glob(f"*/{session_id}.jsonl"))
+            if matches:
+                return decode_project_path(matches[0].parent.name)
+    except Exception:
+        pass
+
+    try:
+        from resume_resume.session_utils import find_grok_session_file
+
+        grok = find_grok_session_file(session_id)
+        if grok is not None:
+            return grok[1]
+    except Exception:
+        pass
+    return ""
 
 
 def _session_meta(session_id: str) -> dict[str, Any]:

--- a/resume_resume/session_utils.py
+++ b/resume_resume/session_utils.py
@@ -10,17 +10,167 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+# Default Grok Build session root. Overridable in tests via session_tool(..., grok_root=).
+GROK_SESSIONS_DIR = Path.home() / ".grok" / "sessions"
+
+# Cache: session_id → bool (is under grok root). Invalidated when root mtime changes.
+_GROK_ID_CACHE: dict[str, bool] = {}
+_GROK_ROOT_MTIME: float | None = None
+
+
+def _grok_root_mtime(root: Path) -> float | None:
+    try:
+        return root.stat().st_mtime if root.is_dir() else None
+    except OSError:
+        return None
+
+
+def is_grok_session_id(session_id: str, *, grok_root: Path | None = None) -> bool:
+    """True if session_id is a directory under ~/.grok/sessions/<project>/<id>/.
+
+    Path existence is the source of truth — Grok IDs look like UUIDs and cannot
+    be distinguished from Claude UUIDs by format alone (see MS-0002 / TASK-0025).
+    """
+    if not session_id or session_id.startswith("rollout-"):
+        return False
+    # Guard against path traversal in globs
+    if "/" in session_id or "\\" in session_id or ".." in session_id:
+        return False
+
+    root = grok_root if grok_root is not None else GROK_SESSIONS_DIR
+    global _GROK_ID_CACHE, _GROK_ROOT_MTIME
+    mtime = _grok_root_mtime(root)
+    if grok_root is None:
+        if mtime != _GROK_ROOT_MTIME:
+            _GROK_ID_CACHE = {}
+            _GROK_ROOT_MTIME = mtime
+        cached = _GROK_ID_CACHE.get(session_id)
+        if cached is not None:
+            return cached
+
+    found = False
+    try:
+        if root.is_dir():
+            # One level: <encoded-cwd>/<session_id>/
+            for match in root.glob(f"*/{session_id}"):
+                if match.is_dir():
+                    found = True
+                    break
+    except OSError:
+        found = False
+
+    if grok_root is None:
+        _GROK_ID_CACHE[session_id] = found
+    return found
+
+
+def decode_grok_project_dir(encoded: str) -> str:
+    """Decode a Grok sessions parent dir name into a filesystem cwd.
+
+    Grok encodes cwd as URL-quoted path segments (e.g. ``%2FUsers%2Fme%2Fproj``).
+    """
+    from urllib.parse import unquote
+
+    path = unquote(encoded.replace("%2F", "/").replace("%2f", "/"))
+    if path and not path.startswith("/"):
+        path = "/" + path
+    return path or encoded
+
+
+def find_grok_session_file(
+    session_id: str,
+    *,
+    grok_root: Path | None = None,
+) -> tuple[Path, str] | None:
+    """Locate ``chat_history.jsonl`` (or fallback) for a Grok session id.
+
+    Returns ``(file, project_dir)`` or None. project_dir is the decoded cwd.
+    """
+    if not session_id or session_id.startswith("rollout-"):
+        return None
+    if "/" in session_id or "\\" in session_id or ".." in session_id:
+        return None
+
+    root = grok_root if grok_root is not None else GROK_SESSIONS_DIR
+    try:
+        if not root.is_dir():
+            return None
+        for match in root.glob(f"*/{session_id}"):
+            if not match.is_dir():
+                continue
+            for name in ("chat_history.jsonl", "events.jsonl", "updates.jsonl"):
+                candidate = match / name
+                if candidate.is_file():
+                    project_dir = decode_grok_project_dir(match.parent.name)
+                    return candidate, project_dir
+    except OSError:
+        return None
+    return None
+
+
+def is_claude_session_id(session_id: str, *, projects_dir: Path | None = None) -> bool:
+    """True if ``~/.claude/projects/*/<session_id>.jsonl`` exists."""
+    if not session_id or session_id.startswith("rollout-"):
+        return False
+    if "/" in session_id or "\\" in session_id or ".." in session_id:
+        return False
+    root = projects_dir if projects_dir is not None else Path.home() / ".claude" / "projects"
+    try:
+        if not root.is_dir():
+            return False
+        for match in root.glob(f"*/{session_id}.jsonl"):
+            if match.is_file():
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def session_tool(
+    session_id: str,
+    *,
+    grok_root: Path | None = None,
+    projects_dir: Path | None = None,
+) -> str:
+    """Which CLI produced a session: ``"codex"``, ``"grok"``, or ``"claude"``.
+
+    Rules (TASK-0025 / MS-0002):
+      - ``rollout-*`` → codex
+      - Claude projects path exists → claude (wins over grok if both — pathological)
+      - directory under ``~/.grok/sessions/*/<id>/`` → grok
+      - else → claude
+
+    Dual-path collision is not expected in production (Claude and Grok use
+    separate trees and do not share ids). Claude wins if it ever happens so
+    we do not mislabel a real Claude UUID.
+
+    Lives in resume-resume (not claude-session-commons) so this PR does not
+    change the binary codex|claude helper still used by other packages.
+    """
+    if not session_id:
+        return "claude"
+    if session_id.startswith("rollout-"):
+        return "codex"
+    if is_claude_session_id(session_id, projects_dir=projects_dir):
+        return "claude"
+    if is_grok_session_id(session_id, grok_root=grok_root):
+        return "grok"
+    return "claude"
+
 
 def resume_command(
     session_id: str,
     *,
     fork: bool = False,
     skip_permissions: bool = False,
+    grok_root: Path | None = None,
+    projects_dir: Path | None = None,
 ) -> str:
     """Build the CLI command to resume (or fork) a session, by source.
 
     Claude Code → ``claude --resume <id>`` (``--fork-session`` to fork).
     Codex CLI   → ``codex resume <uuid>`` (``codex fork <uuid>`` to fork),
+    Grok Build  → ``grok --resume <id>``,
     where the UUID is extracted from the rollout filename stem.
 
     ``skip_permissions`` only applies to Claude Code; Codex has no equivalent
@@ -31,9 +181,15 @@ def resume_command(
         is_codex_session_id,
     )
 
-    if is_codex_session_id(session_id):
+    host = session_tool(
+        session_id, grok_root=grok_root, projects_dir=projects_dir
+    )
+    if host == "codex" or is_codex_session_id(session_id):
         verb = "fork" if fork else "resume"
         return f"codex {verb} {codex_session_uuid(session_id)}"
+
+    if host == "grok":
+        return f"grok --resume {session_id}"
 
     cmd = f"claude --resume {session_id}"
     if fork:

--- a/resume_resume/session_utils.py
+++ b/resume_resume/session_utils.py
@@ -114,7 +114,11 @@ def is_claude_session_id(session_id: str, *, projects_dir: Path | None = None) -
         return False
     if "/" in session_id or "\\" in session_id or ".." in session_id:
         return False
-    root = projects_dir if projects_dir is not None else Path.home() / ".claude" / "projects"
+    root = (
+        projects_dir
+        if projects_dir is not None
+        else Path.home() / ".claude" / "projects"
+    )
     try:
         if not root.is_dir():
             return False
@@ -181,9 +185,7 @@ def resume_command(
         is_codex_session_id,
     )
 
-    host = session_tool(
-        session_id, grok_root=grok_root, projects_dir=projects_dir
-    )
+    host = session_tool(session_id, grok_root=grok_root, projects_dir=projects_dir)
     if host == "codex" or is_codex_session_id(session_id):
         verb = "fork" if fork else "resume"
         return f"codex {verb} {codex_session_uuid(session_id)}"

--- a/tests/test_codex_crosstool.py
+++ b/tests/test_codex_crosstool.py
@@ -1,7 +1,7 @@
 """Cross-tool support: Codex messages parse for merge_context, sessions label by tool."""
 
-from claude_session_commons.codex import session_tool
 from resume_resume import mcp_server as ms
+from resume_resume.session_utils import session_tool
 
 CODEX_ROLLOUT = (
     '{"timestamp":"2026-06-12T19:00:30Z","type":"session_meta",'
@@ -15,12 +15,37 @@ CODEX_ROLLOUT = (
 )
 
 
-def test_session_tool_labels_by_source():
+def test_session_tool_labels_by_source(tmp_path):
+    """TASK-0025: rollout→codex; path under grok root→grok; else claude."""
     assert (
         session_tool("rollout-2026-06-12T08-36-57-019ebc0c-9f4f-7362-9d26-fb071dfeecbe")
         == "codex"
     )
-    assert session_tool("ddf7fc98-6c93-40c8-9444-503d8a716dbf") == "claude"
+    # Claude UUID with no grok dir → claude (do not mislabel as grok by format)
+    assert (
+        session_tool(
+            "ddf7fc98-6c93-40c8-9444-503d8a716dbf",
+            grok_root=tmp_path,
+        )
+        == "claude"
+    )
+    # Grok: only when the session directory exists under the grok root
+    # (and no Claude projects path for that id)
+    grok_id = "019f82e1-d2b1-7db1-a82a-77f1f32fd9e6"
+    empty_claude = tmp_path / "empty-claude-projects"
+    empty_claude.mkdir()
+    sess_dir = tmp_path / "%2Ftmp%2Fdemo" / grok_id
+    sess_dir.mkdir(parents=True)
+    (sess_dir / "chat_history.jsonl").write_text("{}\n")
+    assert (
+        session_tool(grok_id, grok_root=tmp_path, projects_dir=empty_claude) == "grok"
+    )
+    # Same id with empty grok root → claude (path is source of truth)
+    empty = tmp_path / "empty-grok"
+    empty.mkdir()
+    assert (
+        session_tool(grok_id, grok_root=empty, projects_dir=empty_claude) == "claude"
+    )
 
 
 def test_read_messages_handles_codex_schema(tmp_path):
@@ -46,3 +71,37 @@ def test_read_messages_codex_keyword_filter(tmp_path):
     out = ms._read_messages(f, "presigned", 6)
     assert len(out["messages"]) == 1
     assert out["messages"][0]["role"] == "assistant"
+
+
+# Grok Build chat_history.jsonl shape (TASK-0027 / MS-0002)
+GROK_HISTORY = (
+    '{"type":"system","content":"You are Grok"}\n'
+    '{"type":"user","content":[{"type":"text","text":"do you see the recent claude code chat about northstar?"}]}\n'
+    '{"type":"assistant","content":[{"type":"text","text":"I will search resume-resume for the northstar session."}]}\n'
+    '{"type":"user","content":"simple string user message about blotter"}\n'
+)
+
+
+def test_read_messages_handles_grok_chat_history(tmp_path):
+    """Grok puts content on the entry, not under message (unlike Claude)."""
+    f = tmp_path / "chat_history.jsonl"
+    f.write_text(GROK_HISTORY)
+
+    out = ms._read_messages(f, "", 10)
+    roles = [m["role"] for m in out["messages"]]
+    texts = " ".join(m["text"] for m in out["messages"])
+
+    assert "user" in roles and "assistant" in roles
+    assert "system" not in roles
+    assert "northstar" in texts
+    assert "blotter" in texts
+
+
+def test_read_messages_grok_keyword_filter(tmp_path):
+    f = tmp_path / "chat_history.jsonl"
+    f.write_text(GROK_HISTORY)
+
+    out = ms._read_messages(f, "blotter", 10)
+    assert len(out["messages"]) == 1
+    assert out["messages"][0]["role"] == "user"
+    assert "blotter" in out["messages"][0]["text"]

--- a/tests/test_codex_crosstool.py
+++ b/tests/test_codex_crosstool.py
@@ -43,9 +43,7 @@ def test_session_tool_labels_by_source(tmp_path):
     # Same id with empty grok root → claude (path is source of truth)
     empty = tmp_path / "empty-grok"
     empty.mkdir()
-    assert (
-        session_tool(grok_id, grok_root=empty, projects_dir=empty_claude) == "claude"
-    )
+    assert session_tool(grok_id, grok_root=empty, projects_dir=empty_claude) == "claude"
 
 
 def test_read_messages_handles_codex_schema(tmp_path):

--- a/tests/test_find_session.py
+++ b/tests/test_find_session.py
@@ -1,8 +1,8 @@
-"""Tests for _find_session — resolves both Claude-Code and Codex sessions.
+"""Tests for _find_session — resolves Claude-Code, Codex, and Grok sessions.
 
-Regression coverage for the bug where search_sessions surfaced Codex
-`rollout-*` ids but _find_session (UUID-gated, ~/.claude/projects-only glob)
-returned None for them, breaking read_session / session_summary / resume etc.
+Regression coverage for:
+- Codex rollout-* ids returned by search but unresolvable by _find_session
+- Grok 019… ids listed in search but missing from Claude/Codex globs (MS-0002 TASK-0026)
 """
 
 from __future__ import annotations
@@ -16,13 +16,15 @@ from resume_resume import mcp_server as ms
 
 CLAUDE_UUID = "019ed161-140f-7791-872c-c752174d4a55"
 CODEX_ID = "rollout-2026-06-16T12-01-00-019ed161-140f-7791-872c-c752174d4a55"
+# Fixture Grok id — same shape as live bug 019f82e1-… (TASK-0026)
+GROK_ID = "019f82e1-d2b1-7db1-a82a-77f1f32fd9e6"
 EXPECTED_KEYS = {"file", "session_id", "project_dir", "mtime", "size"}
 
 
 @pytest.fixture
 def session_roots(tmp_path, monkeypatch):
     """Mirror the real on-disk layout under a temp dir and point the
-    module's PROJECTS_DIR / CODEX_SESSIONS_DIR at it."""
+    module's PROJECTS_DIR / CODEX_SESSIONS_DIR / GROK_SESSIONS_DIR at it."""
     # Claude: ~/.claude/projects/<encoded>/<uuid>.jsonl
     projects = tmp_path / "projects"
     proj_dir = projects / "-Users-dshanklinbv-repos-eidos-agi-resume-resume"
@@ -47,9 +49,19 @@ def session_roots(tmp_path, monkeypatch):
         + "\n"
     )
 
+    # Grok: ~/.grok/sessions/<url-encoded-cwd>/<id>/chat_history.jsonl
+    grok_root = tmp_path / "grok"
+    grok_sess = grok_root / "%2FUsers%2Fdshanklinbv%2Frepos-aic%2Fnorthstar" / GROK_ID
+    grok_sess.mkdir(parents=True)
+    grok_file = grok_sess / "chat_history.jsonl"
+    grok_file.write_text(
+        json.dumps({"role": "user", "content": "find the northstar chat"}) + "\n"
+    )
+
     monkeypatch.setattr(ms, "PROJECTS_DIR", projects)
     monkeypatch.setattr(ms, "CODEX_SESSIONS_DIR", codex_root)
-    return {"claude": claude_file, "codex": codex_file}
+    monkeypatch.setattr(ms, "GROK_SESSIONS_DIR", grok_root)
+    return {"claude": claude_file, "codex": codex_file, "grok": grok_file}
 
 
 def test_codex_rollout_id_resolves(session_roots):
@@ -70,6 +82,26 @@ def test_normal_uuid_still_resolves(session_roots):
     assert result["file"] == session_roots["claude"]
     assert result["session_id"] == CLAUDE_UUID
     assert "resume-resume" in result["project_dir"]
+
+
+def test_grok_session_id_resolves(session_roots):
+    """MS-0002 TASK-0026: Grok ids returned by search must resolve for read_session."""
+    result = ms._find_session(GROK_ID)
+    assert result is not None, "Grok session id should resolve"
+    assert set(result.keys()) == EXPECTED_KEYS
+    assert result["file"] == session_roots["grok"]
+    assert result["session_id"] == GROK_ID
+    assert result["project_dir"] == "/Users/dshanklinbv/repos-aic/northstar"
+    assert result["size"] > 0
+
+
+def test_grok_missing_returns_none(session_roots, monkeypatch, tmp_path):
+    empty = tmp_path / "empty-grok"
+    empty.mkdir()
+    monkeypatch.setattr(ms, "GROK_SESSIONS_DIR", empty)
+    # Claude still works; unknown grok-shaped id does not
+    assert ms._find_session(CLAUDE_UUID) is not None
+    assert ms._find_session("019f9999-0000-7000-8000-000000000001") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ms0002_northstar_golden.py
+++ b/tests/test_ms0002_northstar_golden.py
@@ -1,0 +1,177 @@
+"""Golden regression for MS-0002 multi-host search seams.
+
+Failure mode (2026-07-21): agent asked for recent Claude Code chat about
+northstar. Real session on disk:
+
+  ~/.claude/projects/...-northstar/727d811c-41f7-42f7-b517-ba4c525baf4e.jsonl
+  (cwd ~/repos-aic/northstar — Chapter 4 held pending trade blotter)
+
+Symptoms:
+  1. Grok hot IDs (019f…) labeled tool=claude via codex.session_tool
+  2. Those IDs returned by search but _find_session / read_session → not found
+  3. Hot recency drowned cold northstar summary hit
+
+These tests use fixtures only — no live ~/.grok or Daniel machine state.
+Anchor session id in docstrings: 727d811c-41f7-42f7-b517-ba4c525baf4e
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from resume_resume import mcp_server as ms
+from resume_resume.session_utils import session_tool
+
+# Anchor from 2026-07-21 northstar failure
+NORTHSTAR_CLAUDE_ID = "727d811c-41f7-42f7-b517-ba4c525baf4e"
+GROK_HOT_ID = "019f82e1-d2b1-7db1-a82a-77f1f32fd9e6"
+CODEX_ID = "rollout-2026-06-12T08-36-57-019ebc0c-9f4f-7362-9d26-fb071dfeecbe"
+
+
+def test_session_tool_labels_three_hosts(tmp_path):
+    """TASK-0025: rollout→codex; grok path→grok; else claude."""
+    empty_claude = tmp_path / "empty-claude-projects"
+    empty_claude.mkdir()
+    assert session_tool(CODEX_ID) == "codex"
+    assert (
+        session_tool(
+            NORTHSTAR_CLAUDE_ID, grok_root=tmp_path, projects_dir=empty_claude
+        )
+        == "claude"
+    )
+    sess = tmp_path / "%2FUsers%2Fdemo%2Fnorthstar" / GROK_HOT_ID
+    sess.mkdir(parents=True)
+    (sess / "chat_history.jsonl").write_text("{}\n")
+    assert (
+        session_tool(GROK_HOT_ID, grok_root=tmp_path, projects_dir=empty_claude)
+        == "grok"
+    )
+
+
+def test_find_and_read_all_three_hosts(tmp_path, monkeypatch):
+    """TASK-0026+0027: every resolvable host id is openable by read path."""
+    # Claude
+    projects = tmp_path / "projects"
+    claude_dir = projects / "-Users-dshanklinbv-repos-aic-northstar"
+    claude_dir.mkdir(parents=True)
+    claude_file = claude_dir / f"{NORTHSTAR_CLAUDE_ID}.jsonl"
+    claude_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "GATE C: HOLD chapter 4 until trade blotter",
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "Standing down. Chapter held."}]
+                },
+            }
+        )
+        + "\n"
+    )
+
+    # Codex
+    codex_root = tmp_path / "codex" / "2026" / "06" / "12"
+    codex_root.mkdir(parents=True)
+    codex_file = codex_root / f"{CODEX_ID}.jsonl"
+    codex_file.write_text(
+        '{"type":"session_meta","payload":{"cwd":"/tmp/demo"}}\n'
+        '{"type":"event_msg","payload":{"type":"user_message","message":"codex user"}}\n'
+        '{"type":"event_msg","payload":{"type":"agent_message","message":"codex assistant"}}\n'
+    )
+
+    # Grok
+    grok_root = tmp_path / "grok"
+    grok_sess = grok_root / "%2Ftmp%2Fdemo" / GROK_HOT_ID
+    grok_sess.mkdir(parents=True)
+    grok_file = grok_sess / "chat_history.jsonl"
+    grok_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "content": [
+                    {"type": "text", "text": "do you see the recent claude chat about northstar?"}
+                ],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "assistant",
+                "content": [{"type": "text", "text": "searching resume-resume"}],
+            }
+        )
+        + "\n"
+    )
+
+    monkeypatch.setattr(ms, "PROJECTS_DIR", projects)
+    monkeypatch.setattr(ms, "CODEX_SESSIONS_DIR", tmp_path / "codex")
+    monkeypatch.setattr(ms, "GROK_SESSIONS_DIR", grok_root)
+
+    for sid, needle in (
+        (NORTHSTAR_CLAUDE_ID, "blotter"),
+        (CODEX_ID, "codex user"),
+        (GROK_HOT_ID, "northstar"),
+    ):
+        found = ms._find_session(sid)
+        assert found is not None, f"{sid} must resolve"
+        out = ms._read_messages(found["file"], "", 10)
+        assert out["total"] >= 1, f"{sid} must yield messages"
+        blob = " ".join(m["text"] for m in out["messages"])
+        assert needle in blob, f"{sid} messages should contain {needle!r}"
+
+
+def test_project_dir_resolve_for_northstar_anchor(tmp_path, monkeypatch):
+    """TASK-0029: empty summary project_dir filled from filesystem layout."""
+    from resume_resume import search_index as si
+
+    projects = tmp_path / "projects"
+    proj = projects / "-Users-dshanklinbv-repos-aic-northstar"
+    proj.mkdir(parents=True)
+    (proj / f"{NORTHSTAR_CLAUDE_ID}.jsonl").write_text("{}\n")
+
+    monkeypatch.setattr(
+        "claude_session_commons.discovery.PROJECTS_DIR",
+        projects,
+        raising=False,
+    )
+    # Direct resolve via our helper with patched PROJECTS_DIR import path
+    monkeypatch.setattr(si, "_session_meta", lambda sid: {})
+
+    summary = {
+        "summary": {
+            "title": "Chapter 4 case study held pending trade blotter evidence",
+            "objective": "northstar shelf case study",
+            "state": "HELD",
+            # deliberately no project_dir
+        }
+    }
+    path = tmp_path / f"{NORTHSTAR_CLAUDE_ID}.json"
+    path.write_text(json.dumps(summary))
+
+    # Force _resolve_project_dir to see our projects tree
+    def fake_resolve(sid):
+        if sid == NORTHSTAR_CLAUDE_ID:
+            matches = list(projects.glob(f"*/{sid}.jsonl"))
+            if matches:
+                from claude_session_commons import decode_project_path
+
+                return decode_project_path(matches[0].parent.name)
+        return ""
+
+    monkeypatch.setattr(si, "_resolve_project_dir", fake_resolve)
+    parsed = si._parse_summary_file(path)
+    assert parsed is not None
+    assert "northstar" in (parsed.get("project_dir") or "").lower()

--- a/tests/test_ms0002_northstar_golden.py
+++ b/tests/test_ms0002_northstar_golden.py
@@ -18,7 +18,6 @@ Anchor session id in docstrings: 727d811c-41f7-42f7-b517-ba4c525baf4e
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 from resume_resume import mcp_server as ms
 from resume_resume.session_utils import session_tool
@@ -35,9 +34,7 @@ def test_session_tool_labels_three_hosts(tmp_path):
     empty_claude.mkdir()
     assert session_tool(CODEX_ID) == "codex"
     assert (
-        session_tool(
-            NORTHSTAR_CLAUDE_ID, grok_root=tmp_path, projects_dir=empty_claude
-        )
+        session_tool(NORTHSTAR_CLAUDE_ID, grok_root=tmp_path, projects_dir=empty_claude)
         == "claude"
     )
     sess = tmp_path / "%2FUsers%2Fdemo%2Fnorthstar" / GROK_HOT_ID
@@ -75,7 +72,9 @@ def test_find_and_read_all_three_hosts(tmp_path, monkeypatch):
             {
                 "type": "assistant",
                 "message": {
-                    "content": [{"type": "text", "text": "Standing down. Chapter held."}]
+                    "content": [
+                        {"type": "text", "text": "Standing down. Chapter held."}
+                    ]
                 },
             }
         )
@@ -102,7 +101,10 @@ def test_find_and_read_all_three_hosts(tmp_path, monkeypatch):
             {
                 "type": "user",
                 "content": [
-                    {"type": "text", "text": "do you see the recent claude chat about northstar?"}
+                    {
+                        "type": "text",
+                        "text": "do you see the recent claude chat about northstar?",
+                    }
                 ],
             }
         )

--- a/tests/test_search_merge.py
+++ b/tests/test_search_merge.py
@@ -53,6 +53,7 @@ def test_search_always_queries_cold_even_when_hot_fills_limit(tmp_path, monkeypa
     )
     monkeypatch.setattr(ms, "session_tool", lambda sid: "claude")
     monkeypatch.setattr(ms, "search_index_status", lambda: {"sessions": 1})
+
     # silence progress UI
     class _P:
         def __enter__(self):
@@ -68,14 +69,18 @@ def test_search_always_queries_cold_even_when_hot_fills_limit(tmp_path, monkeypa
 
     out = ms.search_sessions.fn("northstar", limit=5)
     assert cold_calls, "cold index must always be queried"
-    assert cold_calls[0]["limit"] == 5, "cold queried for full limit, not remaining slots"
+    assert cold_calls[0]["limit"] == 5, (
+        "cold queried for full limit, not remaining slots"
+    )
     assert out["cold_matches"] >= 1
     ids = [r["id"] for r in out["items"]]
     # Anchor 727d811c (2026-07-21 northstar failure): must SURFACE in items even when
     # hot has >= limit matches with higher recency scores (fair merge reserves cold slots).
     assert "727d811c-41f7-42f7-b517-ba4c525baf4e" in ids, ids
     cold_in_items = [r for r in out["items"] if r.get("source") == "cold-index"]
-    assert cold_in_items, "at least one cold-index row must appear when cold has matches"
+    assert cold_in_items, (
+        "at least one cold-index row must appear when cold has matches"
+    )
 
 
 def test_search_tool_filter_claude(monkeypatch):
@@ -119,6 +124,7 @@ def test_search_tool_filter_claude(monkeypatch):
             pass
 
     monkeypatch.setattr(ms, "progress", lambda *a, **k: _P())
+
     # Force tool labels without filesystem
     def fake_tool(sid):
         if sid.startswith("rollout-"):

--- a/tests/test_search_merge.py
+++ b/tests/test_search_merge.py
@@ -1,0 +1,133 @@
+"""MS-0002 TASK-0033: cold FTS always runs; hot does not starve cold slots."""
+
+from __future__ import annotations
+
+from resume_resume import mcp_server as ms
+
+
+def test_search_always_queries_cold_even_when_hot_fills_limit(tmp_path, monkeypatch):
+    """When hot returns >= limit matches, cold must still be queried."""
+    cold_calls = []
+
+    def fake_cold(query, **kwargs):
+        cold_calls.append({"query": query, **kwargs})
+        return [
+            {
+                "session_id": "727d811c-41f7-42f7-b517-ba4c525baf4e",
+                "project_dir": "/Users/dshanklinbv/repos-aic/northstar",
+                "mtime": 1_700_000_000.0,
+                "score": 50.0,
+                "title": "Chapter 4 case study held pending trade blotter evidence",
+                "rank": -19.7,
+                "state": "HELD until blotter",
+            }
+        ]
+
+    # Build fake hot sessions that all "match" (need real file paths for health)
+    hot_sessions = []
+    for i in range(15):
+        sid = (
+            f"019f82e1-d2b1-7db1-a82a-77f1f32fd9e{i:01x}"
+            if i < 10
+            else f"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee{i:02d}"
+        )
+        f = tmp_path / f"{sid}.jsonl"
+        f.write_text("northstar loop mission-north-star blotter\n")
+        hot_sessions.append(
+            {
+                "session_id": sid,
+                "project_dir": "/tmp/hot",
+                "mtime": 1_800_000_000.0 + i,
+                "file": f,
+                "size": f.stat().st_size,
+            }
+        )
+
+    monkeypatch.setattr(ms, "_hot_sessions", lambda: hot_sessions[:12])
+    monkeypatch.setattr(ms, "_fresh_sessions", lambda cutoff_after=0.0: [])
+    monkeypatch.setattr(ms, "search_cold_index", fake_cold)
+    monkeypatch.setattr(
+        ms,
+        "_read_session_bytes",
+        lambda s: b"northstar loop mission-north-star blotter",
+    )
+    monkeypatch.setattr(ms, "session_tool", lambda sid: "claude")
+    monkeypatch.setattr(ms, "search_index_status", lambda: {"sessions": 1})
+    # silence progress UI
+    class _P:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def update(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(ms, "progress", lambda *a, **k: _P())
+
+    out = ms.search_sessions.fn("northstar", limit=5)
+    assert cold_calls, "cold index must always be queried"
+    assert cold_calls[0]["limit"] == 5, "cold queried for full limit, not remaining slots"
+    assert out["cold_matches"] >= 1
+    ids = [r["id"] for r in out["items"]]
+    # Anchor 727d811c (2026-07-21 northstar failure): must SURFACE in items even when
+    # hot has >= limit matches with higher recency scores (fair merge reserves cold slots).
+    assert "727d811c-41f7-42f7-b517-ba4c525baf4e" in ids, ids
+    cold_in_items = [r for r in out["items"] if r.get("source") == "cold-index"]
+    assert cold_in_items, "at least one cold-index row must appear when cold has matches"
+
+
+def test_search_tool_filter_claude(monkeypatch):
+    """TASK-0030: tool=claude excludes non-claude hosts."""
+    monkeypatch.setattr(ms, "_hot_sessions", lambda: [])
+    monkeypatch.setattr(ms, "_fresh_sessions", lambda cutoff_after=0.0: [])
+
+    def fake_cold(query, **kwargs):
+        return [
+            {
+                "session_id": "rollout-2026-06-12T08-36-57-019ebc0c-9f4f-7362-9d26-fb071dfeecbe",
+                "project_dir": "/tmp",
+                "mtime": 1_700_000_000.0,
+                "score": 10.0,
+                "title": "codex hit",
+                "rank": -5.0,
+                "state": "codex",
+            },
+            {
+                "session_id": "ddf7fc98-6c93-40c8-9444-503d8a716dbf",
+                "project_dir": "/tmp",
+                "mtime": 1_700_000_001.0,
+                "score": 10.0,
+                "title": "claude hit",
+                "rank": -5.0,
+                "state": "claude",
+            },
+        ]
+
+    monkeypatch.setattr(ms, "search_cold_index", fake_cold)
+    monkeypatch.setattr(ms, "search_index_status", lambda: {})
+
+    class _P:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def update(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(ms, "progress", lambda *a, **k: _P())
+    # Force tool labels without filesystem
+    def fake_tool(sid):
+        if sid.startswith("rollout-"):
+            return "codex"
+        return "claude"
+
+    monkeypatch.setattr(ms, "session_tool", fake_tool)
+
+    out = ms.search_sessions.fn("hit", limit=10, tool="claude")
+    assert out["count"] == 1
+    assert out["items"][0]["id"] == "ddf7fc98-6c93-40c8-9444-503d8a716dbf"
+    assert out["items"][0]["tool"] == "claude"

--- a/tests/test_session_tool_hosts.py
+++ b/tests/test_session_tool_hosts.py
@@ -1,0 +1,82 @@
+"""MS-0002 / TASK-0025: multi-host session_tool labeling.
+
+Detector lives in resume_resume.session_utils (not claude-session-commons.codex)
+so the binary codex|claude helper used by other packages is unchanged.
+"""
+
+from pathlib import Path
+
+from resume_resume.session_utils import is_grok_session_id, resume_command, session_tool
+
+CLAUDE_ID = "ddf7fc98-6c93-40c8-9444-503d8a716dbf"
+GROK_ID = "019f82e1-d2b1-7db1-a82a-77f1f32fd9e6"
+CODEX_ID = "rollout-2026-06-12T08-36-57-019ebc0c-9f4f-7362-9d26-fb071dfeecbe"
+
+
+def _make_grok_session(root: Path, session_id: str = GROK_ID) -> Path:
+    sess = root / "%2FUsers%2Fdemo%2Fproj" / session_id
+    sess.mkdir(parents=True)
+    (sess / "chat_history.jsonl").write_text('{"role":"user","text":"hi"}\n')
+    return sess
+
+
+def test_session_tool_codex_rollout_prefix():
+    assert session_tool(CODEX_ID) == "codex"
+
+
+def test_session_tool_claude_when_not_under_grok(tmp_path):
+    assert session_tool(CLAUDE_ID, grok_root=tmp_path) == "claude"
+    # UUID-ish 019… is still claude without a grok directory
+    assert session_tool(GROK_ID, grok_root=tmp_path) == "claude"
+
+
+def test_session_tool_grok_when_directory_exists(tmp_path):
+    _make_grok_session(tmp_path)
+    empty_claude = tmp_path / "empty-claude-projects"
+    empty_claude.mkdir()
+    assert (
+        session_tool(GROK_ID, grok_root=tmp_path, projects_dir=empty_claude) == "grok"
+    )
+    assert is_grok_session_id(GROK_ID, grok_root=tmp_path) is True
+
+
+def test_session_tool_claude_wins_if_both_trees(tmp_path):
+    """Pathological dual existence: Claude project path wins over grok dir."""
+    _make_grok_session(tmp_path)
+    projects = tmp_path / "claude-projects"
+    proj = projects / "-Users-demo-northstar"
+    proj.mkdir(parents=True)
+    (proj / f"{GROK_ID}.jsonl").write_text("{}\n")
+    assert session_tool(GROK_ID, grok_root=tmp_path, projects_dir=projects) == "claude"
+
+
+def test_session_tool_rejects_path_traversal(tmp_path):
+    assert session_tool("../evil", grok_root=tmp_path) == "claude"
+    assert session_tool("a/b", grok_root=tmp_path) == "claude"
+    assert is_grok_session_id("a/b", grok_root=tmp_path) is False
+
+
+def test_session_tool_empty_id(tmp_path):
+    assert session_tool("", grok_root=tmp_path) == "claude"
+
+
+def test_resume_command_routes_by_host(tmp_path):
+    _make_grok_session(tmp_path)
+    empty_claude = tmp_path / "empty-claude-projects"
+    empty_claude.mkdir()
+    assert resume_command(CODEX_ID).startswith("codex resume ")
+    assert (
+        resume_command(GROK_ID, grok_root=tmp_path, projects_dir=empty_claude)
+        == f"grok --resume {GROK_ID}"
+    )
+    assert resume_command(
+        CLAUDE_ID, grok_root=tmp_path, projects_dir=empty_claude
+    ).startswith("claude --resume ")
+
+
+def test_mcp_server_imports_local_session_tool():
+    """mcp_server must not re-export the codex-only labeler for host labeling."""
+    from resume_resume import mcp_server as ms
+    from resume_resume.session_utils import session_tool as local_st
+
+    assert ms.session_tool is local_st


### PR DESCRIPTION
## Summary

Fixes the multi-host search failure mode that made “find the recent Claude Code chat about northstar” fail (2026-07-21). Grok sessions were labeled as Claude, unreadable after search, and hot recency drowned cold Claude hits.

**Anchor session:** `727d811c-41f7-42f7-b517-ba4c525baf4e` (`~/repos-aic/northstar`, ch4 blotter HOLD).

### Docket (MS-0002)
| Task | Status |
|------|--------|
| TASK-0025 session_tool host identity | Done |
| TASK-0026 `_find_session` Grok resolve | Done |
| TASK-0027 Grok `read_session` parse | Done |
| TASK-0033 cold always + fair merge | Done |
| TASK-0028 hot AND / cold OR docs | Done |
| TASK-0029 project_dir backfill | Done |
| TASK-0030 `tool=` filter | Done |
| TASK-0031 golden fixtures | Done |
| TASK-0032 prompt-pollution strip | **Deferred** |

### Changes
- Local `session_tool` (not codex binary helper): rollout→codex; Claude path→claude; Grok path→grok; Claude wins dual-path pathological case
- `_find_session` + Grok chat_history content shape in `_read_messages`
- Search always queries cold for full `limit`; fair merge reserves cold slots
- `tool=` filter on `search_sessions` / `recent_sessions` applied **before** limit
- Indexer fills empty `project_dir` from filesystem when meta missing

## Test plan
- [x] `pytest tests/test_session_tool_hosts.py tests/test_find_session.py tests/test_search_merge.py tests/test_ms0002_northstar_golden.py tests/test_codex_crosstool.py tests/test_fts_query.py tests/test_resume_command.py` → **36 passed**
- [ ] CI green on PR
- [ ] Manual: `search_sessions("blotter", tool="claude")` surfaces 727d811c when indexed

## Scope
PR is seams-only on branch from `origin/master`. Does **not** include dirty master WIP (daemon/tui/etc.).